### PR TITLE
feat: Support encoding.TextUnmarshaler and encoding.TextMarshaler

### DIFF
--- a/encode.go
+++ b/encode.go
@@ -1,6 +1,7 @@
 package lamenv
 
 import (
+	"encoding"
 	"fmt"
 	"os"
 	"reflect"
@@ -25,6 +26,14 @@ func (l *Lamenv) encode(value reflect.Value, parts []string) error {
 
 	if p, ok := ptr.Interface().(Marshaler); ok {
 		return p.MarshalEnv(parts)
+	}
+
+	if p, ok := ptr.Interface().(encoding.TextMarshaler); ok {
+		raw, err := p.MarshalText()
+		if err != nil {
+			return err
+		}
+		return os.Setenv(buildEnvVariable(parts), string(raw))
 	}
 
 	switch v.Kind() {


### PR DESCRIPTION
This PR makes usage of the go built-in Marshaler/Unmarshaler to encode/decode environment variable. 

It enables for example the usage of some clever structure like the prometheus' ``model.Duration`` (supporting days and weeks)